### PR TITLE
Adds bounds on megaparsec.

### DIFF
--- a/coda.cabal
+++ b/coda.cabal
@@ -286,7 +286,7 @@ library
     bound,
     bytestring-short,
     llvm-hs-pure ^>= 6.0,
-    megaparsec,
+    megaparsec >= 6.0 && < 7.0,
     prettyprinter,
     prettyprinter-ansi-terminal,
     text-short


### PR DESCRIPTION
This is a stopgap measure until I work out how to work the
Megaparsec 7.0 changes to the Stream interface into `coda`.