### PR TITLE
HasDelta Token instance

### DIFF
--- a/src/dyck/Dyck.hs
+++ b/src/dyck/Dyck.hs
@@ -115,8 +115,8 @@ layoutToken (Dyck l ms r s _ e) i a = Dyck l ms r (snocCat s a) i e
 
 -- | O(1)
 close :: Dyck -> Located Pair -> Dyck
-close (Dyck l ms (r' :> Opening dp rs) s _ e) dq
- | extract dp == extract dq  = Dyck l ms r' (Cat.singleton $ nested dp (rs<>s)) def e
+close (Dyck l ms (r' :> Opening dp@(Located lp p) rs) s _ e) dq@(Located lq q)
+ | p == q  = Dyck l ms r' (Cat.singleton $ nested p lp (rs<>s) lq) def e
  | otherwise = Dyck l ms r' (Cat.singleton $ mismatch dp dq (rs<>s)) def (snocCat e $! MismatchError dp dq)
 close (Dyck l ms _ s _ e) dq = Dyck (snocCat l $ Closing (ms <> s) dq) mempty mempty mempty def e
 
@@ -134,8 +134,8 @@ instance Default Dyck where
 instance Semigroup Dyck where
   m <> Dyck Empty Empty Empty Empty _ Empty = m
   Dyck l0 m0 r0 s0 _ e0 <> Dyck l1 m1 r1 s1 k1 e1 = go l0 m0 r0 s0 e0 l1 m1 r1 s1 k1 e1 where
-    go l2 m2 (r2' :> Opening dp xs) s2 e2 (Closing ys dq :< l3') m3 r3 s3 k3 e3
-      | extract dp == extract dq  = go l2 m2 r2' (Cat.singleton $ nested dp (xs<>s2<>ys)) e2 l3' m3 r3 s3 k3 e3
+    go l2 m2 (r2' :> Opening dp@(Located lp p) xs) s2 e2 (Closing ys dq@(Located lq q) :< l3') m3 r3 s3 k3 e3
+      | p == q    = go l2 m2 r2' (Cat.singleton $ nested p lp (xs<>s2<>ys) lq) e2 l3' m3 r3 s3 k3 e3
       | otherwise = go l2 m2 r2' (Cat.singleton $ mismatch dp dq (xs<>s2<>ys)) (snocCat e2 $! MismatchError dp dq) l3' m3 r3 s3 k3 e3
     go l2 m2 (r2' :> Opening dp xs) s2 e2 _ m3 r3 s3 k3 e3 = Dyck l2 m2 ((r2' :> Opening dp (xs<>s2<>m3))<>r3) s3 k3 (e2<>e3)
     go l2 m2 _ s2 e2 (Closing xs dp :< l3') m3 r3 s3 k3 e3 = Dyck (l2<>(Closing (m2<>s2<>xs) dp :< l3')) m3 r3 s3 k3 (e2<>e3)

--- a/src/dyck/Token.hsig
+++ b/src/dyck/Token.hsig
@@ -42,7 +42,7 @@ instance Show LayoutMode
 instance Read LayoutMode
 instance Default LayoutMode
 
-nested :: Located Pair -> Cat Token -> Token
+nested :: Pair -> Delta -> Cat Token -> Delta -> Token
 mismatch :: Located Pair -> Located Pair -> Cat Token -> Token
 unmatchedOpening :: Located Pair -> Token
 unmatchedClosing :: Located Pair -> Token

--- a/src/lsp/Language/Server/Protocol.hs
+++ b/src/lsp/Language/Server/Protocol.hs
@@ -291,7 +291,7 @@ data Request = Request
 
 instance FromJSON Request where
   parseJSON = withObject "Request" $ \v -> do
-    ver <- v .: "jsonrpc" -- check for jsonprc validity
+    ver <- v .: "jsonrpc" -- check for jsonrpc validity
     when (ver /= jsonRpcVersion) $ fail "invalid JSON-RPC version"
     Request <$> v .:? "id"
             <*> v .: "method"

--- a/src/token/Syntax/Token.hs
+++ b/src/token/Syntax/Token.hs
@@ -92,21 +92,21 @@ data Keyword
   deriving (Eq,Ord,Show,Read,Ix,Enum,Bounded,Data,Generic)
 
 data Token
-  = Token        {-# unpack #-} !Delta {-# unpack #-} !Text -- as yet uninterpreted lexemes
-  | TokenName    {-# unpack #-} !Delta !Name
-  | TokenKeyword {-# unpack #-} !Delta !Keyword
-  | TokenInteger {-# unpack #-} !Delta !Integer
-  | TokenDouble  {-# unpack #-} !Delta {-# unpack #-} !Double
-  | TokenString  {-# unpack #-} !Delta {-# unpack #-} !Text
-  | TokenChar    {-# unpack #-} !Delta {-# unpack #-} !Char
-  | TokenNested  {-# unpack #-} !(Located Pair) !(Cat Token)
+  = Token         {-# unpack #-} !Delta {-# unpack #-} !Text -- as yet uninterpreted lexemes
+  | TokenName     {-# unpack #-} !Delta !Name
+  | TokenKeyword  {-# unpack #-} !Delta !Keyword
+  | TokenInteger  {-# unpack #-} !Delta !Integer
+  | TokenDouble   {-# unpack #-} !Delta {-# unpack #-} !Double
+  | TokenString   {-# unpack #-} !Delta {-# unpack #-} !Text
+  | TokenChar     {-# unpack #-} !Delta {-# unpack #-} !Char
+  | TokenNested   !Pair {-# unpack #-} !Delta !(Cat Token) {-# unpack #-} !Delta
   | TokenMismatch {-# unpack #-} !(Located Pair) {-# unpack #-} !(Located Pair) !(Cat Token)
   | TokenUnmatchedOpening {-# unpack #-} !(Located Pair)
   | TokenUnmatchedClosing {-# unpack #-} !(Located Pair)
   | TokenLexicalError {-# unpack #-} !Delta String
   deriving (Eq,Ord,Show,Read)
 
-nested :: Located Pair -> Cat Token -> Token
+nested :: Pair -> Delta -> Cat Token -> Delta -> Token
 nested = TokenNested
 
 mismatch :: Located Pair -> Located Pair -> Cat Token -> Token
@@ -131,7 +131,7 @@ instance Relative Token where
     go d (TokenDouble d' f) = TokenDouble (d+d') f
     go d (TokenString d' l) = TokenString (d+d') l
     go d (TokenChar d' l) = TokenChar (d+d') l
-    go d (TokenNested dp ts) = TokenNested (rel d dp) (rel d ts)
+    go d (TokenNested p dp ts dq) = TokenNested p (rel d dp) (rel d ts) (rel d dq)
     go d (TokenMismatch dp dq ts) = TokenMismatch (rel d dp) (rel d dq) (rel d ts)
     go d (TokenUnmatchedOpening dp) = TokenUnmatchedOpening (rel d dp)
     go d (TokenUnmatchedClosing dp) = TokenUnmatchedClosing (rel d dp)

--- a/src/token/Syntax/Token.hs
+++ b/src/token/Syntax/Token.hs
@@ -137,6 +137,22 @@ instance Relative Token where
     go d (TokenUnmatchedClosing dp) = TokenUnmatchedClosing (rel d dp)
     go d (TokenLexicalError d' s) = TokenLexicalError (d+d') s
 
+-- I don't see this having any legitimate uses after we start working with spans
+-- directly. -- Ed 2
+instance HasDelta Token where
+  delta (Token d _) = d
+  delta (TokenName d _) = d
+  delta (TokenKeyword d _) = d
+  delta (TokenInteger d _) = d
+  delta (TokenDouble d _) = d
+  delta (TokenString d _) = d
+  delta (TokenChar d _) = d
+  delta (TokenNested _ d _ _) = d
+  delta (TokenMismatch (Located d _) _ _) = d
+  delta (TokenUnmatchedOpening (Located d _)) = d
+  delta (TokenUnmatchedClosing (Located d _)) = d
+  delta (TokenLexicalError d _) = d
+
 data Pair = Brace | Bracket | Paren
   deriving (Eq,Ord,Show,Read,Ix,Enum,Bounded,Generic)
 


### PR DESCRIPTION
It's a bit of an odd instance because it discards information about where the *end* of the tokens are. I think that's fine, because this instance won't likely be useful when we're (finally) working with spans.

Depends on #10; it could theoretically not do so, but otherwise it's ambiguous whether the `Located Pair` in `TokenNested` is supposed to be placed at the start or end `Pair`.