### PR TITLE
Tighten lower bound

### DIFF
--- a/coda.cabal
+++ b/coda.cabal
@@ -52,7 +52,7 @@ common app
 common base
   default-language: Haskell2010
   ghc-options: -Wall
-  build-depends: base >= 4.10 && < 5
+  build-depends: base >= 4.11 && < 5
 
 common aeson                { build-depends: aeson >= 1.1 && < 1.3 }
 common array                { build-depends: array }


### PR DESCRIPTION
This doesn't build with GHC 8.2.2
relevant: https://github.com/haskell/cabal/issues/4908

If we make some minor code tweaks it could work for 8.2.1 (?), but I think being conservative here is a better user experience than telling 8.2 users to downgrade their version.